### PR TITLE
cosmetic and other changes to allow vignette to complete as written

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: ProstatePackage
 Type: Package
 Title: Prostate Cancer Outcome Predictor
-Version: 0.1
-Date: 2016-02-23
+Version: 0.1.0
+Date: 2017-01-21
 Author: Yates Coley
 Maintainer: Julia Bindman <jbindman@jhu.edu>
 Description: A working package to synthesize the work of Yates Coley

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: A working package to synthesize the work of Yates Coley
 License: JHU
 LazyData: TRUE
 RoxygenNote: 5.0.1
-Imports: bayesm,
+Imports: bayesm, 
          lme4,
          Matrix,
          splines,

--- a/R/RJAGSprep.R
+++ b/R/RJAGSprep.R
@@ -19,6 +19,7 @@
 #' 8. Define other jags settings
 #' 9. Write model definition
 #'
+#' @importFrom bayesm rwishart
 #' @export
 RJAGSprep <- function(pt, IOP = TRUE) {
 

--- a/R/RJAGSprep.R
+++ b/R/RJAGSprep.R
@@ -6,7 +6,6 @@
 #' @param pt Dataframe of formatted active surveillance data created by the function fillPatientTables()
 #' @param IOP TRUE if biopsy and surgery occurences are informative of the underlying GS, FALSE if non-informative.
 #' @return List of arguments for running analysis using RJAGS: \code{jags_data} (data), \code{inits} (inits), \code{parameters.to.save} (parameters.to.save).
-#' @export
 #'
 #' WORKFLOW
 #' 0. Load packages and  necessary data.

--- a/vignettes/IOP-jags-model.txt
+++ b/vignettes/IOP-jags-model.txt
@@ -1,0 +1,91 @@
+model {
+
+###PRIORS FOR LATENT CLASS MODEL
+
+#flat prior on probability of latent class membership for all subjects
+p_eta ~ dbeta(1,1)
+
+
+###PRIORS FOR MIXED MODEL
+#model correlated random effects distribution
+
+for (index in 1:d_Z) {
+	xi[index]~dunif(0,100)
+	for(k in 1:K){
+		mu_raw[index,k]~dnorm(0, 0.01) 
+		mu[index,k]<-xi[index] *mu_raw[index,k]}  }
+
+for(k in 1:K){
+	mu_int[k] <- mu[1,k] 
+	mu_slope[k] <- mu[2,k]}
+
+#same covariance matrix (Sigma_B) across latent classes
+Tau_B_raw ~ dwish(I_d_Z[,], (d_Z+1)) 
+Sigma_B_raw[1:d_Z, 1:d_Z] <- inverse(Tau_B_raw[1:d_Z, 1:d_Z])	
+for (index in 1:d_Z){
+		sigma[index]<-xi[index]*sqrt(Sigma_B_raw[index,index]) }
+
+sigma_int <- sigma[1] 
+sigma_slope <- sigma[2] 
+
+rho_int_slope <- Sigma_B_raw[1,2]/sqrt(Sigma_B_raw[1,1] * Sigma_B_raw[2,2])
+cov_int_slope <- rho_int_slope*sigma_int*sigma_slope 
+
+##residual variance, independent of correlated random effects, same across classes
+sigma_res ~ dunif(0, 1) 
+tau_res <- pow(sigma_res,-2)
+
+##fixed effects
+for(index in 1:d_X){
+	beta[index] ~ dnorm(0,0.01)}
+
+
+###PRIORS FOR OUTCOME MODEL
+#last element in each gamma is coefficient for class membership eta=1
+for(index in 1:(d_U_BX+1)){nu_BX[index] ~ dnorm(0,0.01)}
+for(index in 1:(d_V_RC+1)){gamma_RC[index] ~ dnorm(0,0.01)}
+for(index in 1:(d_W_SURG+2)){omega_SURG[index] ~ dnorm(0,0.01)}
+
+
+###LIKELIHOOD
+
+##latent variable for true cancer state
+for(i in 1:n_eta_known){
+	eta_data[i] ~ dbern(p_eta)
+	eta[i] <- eta_data[i] + 1} #this is for those with path reports from surgery, eta known 
+
+for(i in (n_eta_known+1):n){
+	eta_hat[(i-n_eta_known)] ~ dbern(p_eta)
+	eta[i] <- eta_hat[(i-n_eta_known)] + 1}  #for those without surgery
+
+##linear mixed effects model for PSA 
+#generate random intercept and slope for individual given latent class
+for (i in 1:n) {
+	B_raw[i,1:d_Z] ~ dmnorm(mu_raw[1:d_Z,eta[i]], Tau_B_raw[1:d_Z, 1:d_Z])
+	for(index in 1:d_Z){b_vec[i,index] <- xi[index]*B_raw[i,index]} }
+
+#fit LME
+for(j in 1:n_obs_psa){ 
+	mu_obs_psa[j] <- inprod(b_vec[subj_psa[j],1:d_Z], Z[j,1:d_Z])  + (beta[1]*X[j,1:d_X]) 
+	Y[j] ~ dnorm(mu_obs_psa[j], tau_res) }
+
+
+##all biopsy data
+
+#logistic regression for biopsy
+for(j in 1:n_bx){
+	logit(p_bx[j]) <-inprod(nu_BX[1:d_U_BX], U_BX[j,1:d_U_BX]) + nu_BX[(d_U_BX+1)]*equals(eta[subj_bx[j]],2)  
+	BX[j] ~ dbern(p_bx[j]) }
+
+#logistic regression for reclassification 	
+for(j in 1:n_rc){
+	logit(p_rc[j]) <-inprod(gamma_RC[1:d_V_RC], V_RC[j,1:d_V_RC]) + gamma_RC[(d_V_RC+1)]*equals(eta[subj_rc[j]],2) 
+	RC[j] ~ dbern(p_rc[j]) }
+
+#logistic regression for surgery 	
+for(j in 1:n_surg){
+	logit(p_surg[j]) <-inprod(omega_SURG[1:d_W_SURG], W_SURG[j,1:d_W_SURG]) + omega_SURG[(d_W_SURG+1)]*equals(eta[subj_surg[j]],2)  + omega_SURG[(d_W_SURG+2)]*equals(eta[subj_surg[j]],2)*W_SURG[j,d_W_SURG]  
+	SURG[j] ~ dbern(p_surg[j]) }
+
+	
+ }

--- a/vignettes/prostate-package-vignette.Rmd
+++ b/vignettes/prostate-package-vignette.Rmd
@@ -1,10 +1,16 @@
 ---
-output: html_document
+title: "Prostate Package Vignette" 
+author: "Yates Coley & Julia Bindman" 
+date: "`r format(Sys.time(), '%B %d, %Y')`"
+vignette: >
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteIndexEntry{Prostate cancer: individualized risk modeling}
+  %\VignetteEncoding{UTF-8}
+output:
+  rmarkdown::html_document:
+    number_sections: yes
+    toc: yes
 ---
---- title: "Prostate Package Vignette" author: "Yates Coley & Julia Bindman" date: "`r Sys.Date()`" 
-output: rmarkdown::html_vignette vignette: > %\VignetteIndexEntry{Vignette
-Title} %\VignetteEngine{knitr::rmarkdown} %\VignetteEncoding{UTF-8} ---
-
 
 #Loading Data 
 To analyze your code, you must first load in data from various clinical data sources. Load in data from .csv files for patient data, PSA data, biopsy data, and surgical data. Each .csv file must be saved to your local directory. Below, we describe the characteristics and variables of each dataset needed for input.

--- a/vignettes/prostate-package-vignette.Rmd
+++ b/vignettes/prostate-package-vignette.Rmd
@@ -71,8 +71,9 @@ Variable (column) names must be specified *exactly* as given above.
 #Shaping data
 Call function fillPatientTables to create dataframes based on combined data sources.
 ```{r, results = "hide", message = FALSE}
+library(ProstatePackage)
 #having issues from remote download
-ptDataframes <- ProstatePackage::fillPatientTables(demo_data, psa_data, bx_data, surg_data, IOP = TRUE)
+ptDataframes <- fillPatientTables(demo_data, psa_data, bx_data, surg_data, IOP = TRUE)
 ```
 
 This function will check the input datasets to ensure data meet the requirements detailed above. If data are not formatted properly, error messages will be produced and the function will not return the necessary dataframes for proceeding with analysis.
@@ -91,7 +92,7 @@ Variable (column) names must be specified *exactly* as given above.
 
 Next, RJAGSprep will take the formatted dataframe created by fillPatientTables as input and prepare necessary arguments to complete the analysis in RJAGS. 
 ```{r, results = "hide", message = FALSE}
-jagsPrep <- ProstatePackage::RJAGSprep(pt = ptDataframes, IOP=TRUE)
+jagsPrep <- RJAGSprep(pt = ptDataframes, IOP=TRUE)
 ```
 Note that the JAGS model (model.file) is automatically written to your current working directory by RJAGSprep. Required fields are: 
 
@@ -99,9 +100,9 @@ Note that the JAGS model (model.file) is automatically written to your current w
 * IOP Boolean, TRUE if biopsy and surgery occurences are informative of the underlying GS, FALSE if non-informative. TRUE default
 
 Finally, run the analysis with RJAGS according to desired specifications for chain length, burn-in, etc. (The example below runs a single short chain.)
-``````{r, eval = FALSE}
+``````{r, eval = TRUE}
 library(R2jags)
-ex.jags<-jags(data=RJAGSprepfull$jags_data, inits=RJAGSprepfull$inits, parameters.to.save=RJAGSprepfull$parameters.to.save, model.file="IOP-jags-model.txt", n.chains=1, n.iter=50, n.burnin=10, n.thin=1)
+ex.jags<-jags(data=jagsPrep$jags_data, inits=jagsPrep$inits, parameters.to.save=jagsPrep$parameters.to.save, model.file="IOP-jags-model.txt", n.chains=1, n.iter=50, n.burnin=10, n.thin=1)
 ```
 See documentation for R2jags for details on jags output.
 
@@ -110,7 +111,7 @@ See documentation for R2jags for details on jags output.
 Use this function to print an individual's data from various clinical data sources.
 
 ```{r}
-inputPatient <- ProstatePackage:::printIndividualData(pt.id = 5, pt = ptDataframes)
+inputPatient <- printIndividualData(pt.id = 5, pt = ptDataframes)
 ```
 The function returns and prints a readable formatted table of patient data. Required fields are:
 
@@ -123,8 +124,8 @@ The function returns and prints a readable formatted table of patient data. Requ
 
 Use this function to plot an individual's data.
 
-```{r, eval = FALSE}
-ProstatePackage::plotIndividualData(pt.id = 60, what.data="both", log.scale=T, plot.psad=F, pt = ptDataframes)
+```{r, eval = TRUE}
+plotIndividualData(pt.id = 60, what.data="both", log.scale=T, plot.psad=F, pt = ptDataframes)
 ```
 The function plots various clinical data for an individual patiet. Required fields are:
 


### PR DESCRIPTION
The vignette YAML header is improved.

rwishart from bayesm needed to be formally imported 

the IOP-jags-model.txt must be present for jags to run in vignettes

crashes at

`> plotIndividualData(pt.id = 60, what.data="both", log.scale=T, plot.psa .... [TRUNCATED] 
Error in match(x, table, nomatch = 0L) : 
  'match' requires vector arguments

Enter a frame number, or 0 to exit   

 1: source("prostate-package-vignette.R", echo = TRUE)
 2: withVisible(eval(ei, envir))
 3: eval(ei, envir)
 4: eval(ei, envir)
 5: prostate-package-vignette.R#29: plotIndividualData(pt.id = 60, what.data = 
 6: subset(psa.data, id %in% closestK)
 7: subset.data.frame(psa.data, id %in% closestK)
 8: eval(e, x, parent.frame())
 9: eval(e, x, parent.frame())
10: id %in% closestK
11: match(x, table, nomatch = 0)
`

